### PR TITLE
Minor UI fixes

### DIFF
--- a/src/models/viewModel.js
+++ b/src/models/viewModel.js
@@ -51,7 +51,8 @@ class ViewModel extends EventCreator {
     domElem.addEventListener('wheel', this.handleMouse);
     domElem.addEventListener('mousemove', this.handleMouseMove);
     domElem.addEventListener('mousedown', this.handleMouseDown);
-    domElem.addEventListener('mouseup', this.handleMouseUp);
+    // capture mouse-up events on the window so that drag operations are ended no matter where the mouse is at the time (even outside the window)
+    window.addEventListener('mouseup', this.handleMouseUp);
     domElem.addEventListener('dblclick', this.handleDoubleClick);
   }
 
@@ -61,7 +62,7 @@ class ViewModel extends EventCreator {
     domElem.removeEventListener('wheel', this.handleMouse);
     domElem.removeEventListener('mousemove', this.handleMouseMove);
     domElem.removeEventListener('mousedown', this.handleMouseDown);
-    domElem.removeEventListener('mouseup', this.handleMouseUp);
+    window.removeEventListener('mouseup', this.handleMouseUp);
     domElem.removeEventListener('dblclick', this.handleDoubleClick);
   }
 


### PR DESCRIPTION
- Prevent native browser behavior such as track-pad zoom and two-finger swipes interfering with the canvas track interface
- End drag operations on mouse-up no matter where the mouse is – if a drag operation is started and the mouse is released anywhere outside the canvas (such as the header) the drag operation continues and the track is 'stuck' to the mouse