### PR TITLE
Match previous behavior of rawBasePairToChromosomeBasePair

### DIFF
--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -33,10 +33,14 @@ class Util {
 
   static chromosomeRelativeBasePair(absoluteBasePair) {
     const chromosomeIndex = this.chromosomeIndex(absoluteBasePair);
-    return {
-      chromosomeIndex: chromosomeIndex,
-      basePair: absoluteBasePair - CHROMOSOME_START_BASE_PAIRS[chromosomeIndex],
-    };
+    if (chromosomeIndex == null) {
+      return null;
+    } else {
+      return  {
+        chromosomeIndex: chromosomeIndex,
+        basePair: absoluteBasePair - CHROMOSOME_START_BASE_PAIRS[chromosomeIndex],
+      };
+    }
   }
 
   static floorToMultiple(x, k) {


### PR DESCRIPTION
Minor update to last PR - when out of bounds this chromosomeRelativeBasePair should return null (this fixes NaNs on the x-axis)