### PR TITLE
Fix canvas mousemove events firing when not over the canvas

### DIFF
--- a/src/models/viewModel.js
+++ b/src/models/viewModel.js
@@ -242,20 +242,24 @@ class ViewModel extends EventCreator {
   }
 
   handleMouseUp(evt) {
-    if (this.selectEnabled) {
-      const windowSize = this.windowSize;
-      const start = Math.min(this.startDragCoord[0], this.lastDragCoord[0]);
-      const end = Math.max(this.startDragCoord[0], this.lastDragCoord[0]);
-      const startBp = Util.basePairForScreenX(start, this.startBasePair, this.basePairsPerPixel, windowSize);
-      const endBp = Util.basePairForScreenX(end, this.startBasePair, this.basePairsPerPixel, windowSize);
-      if (startBp !== endBp) this.notifyListeners(VIEW_EVENT_SELECTION, { startBp, endBp });
-    } else {
-      this.notifyListeners(VIEW_EVENT_CLICK, this.lastDragCoord);
+    if (evt.target === this.domElem || this.dragEnabled) {
+      evt.preventDefault();
+
+      if (this.selectEnabled) {
+        const windowSize = this.windowSize;
+        const start = Math.min(this.startDragCoord[0], this.lastDragCoord[0]);
+        const end = Math.max(this.startDragCoord[0], this.lastDragCoord[0]);
+        const startBp = Util.basePairForScreenX(start, this.startBasePair, this.basePairsPerPixel, windowSize);
+        const endBp = Util.basePairForScreenX(end, this.startBasePair, this.basePairsPerPixel, windowSize);
+        if (startBp !== endBp) this.notifyListeners(VIEW_EVENT_SELECTION, { startBp, endBp });
+      } else {
+        this.notifyListeners(VIEW_EVENT_CLICK, this.lastDragCoord);
+      }
+      this.dragEnabled = false;
+      this.lastDragCoord = null;
+      this.startDragCoord = null;
+      this.notifyViewStateChange(true);
     }
-    this.dragEnabled = false;
-    this.lastDragCoord = null;
-    this.startDragCoord = null;
-    this.notifyViewStateChange(true);
   }
 
   handleDoubleClick(evt) {


### PR DESCRIPTION
Fix issue #47 and #49 where canvas mouse events are fired when mousing over the sidebar

Explanation:
- An earlier change tried to improve interaction by enabling mouse events handling when dragging outside the canvas.
- The bug I introduced was that mouse events were handled outside the canvas whether or not drag was active, this mean they overrode some actions when they shouldn't

The fix is to only override mouse event handling when dragging is active

![mar-15-2018 12-03-54](https://user-images.githubusercontent.com/3742992/37464033-0197deb8-284f-11e8-8515-b93825bb500d.gif)