### PR TITLE
add /query api

### DIFF
--- a/src/models/api.js
+++ b/src/models/api.js
@@ -125,6 +125,13 @@ class GenomeAPI {
 			return data.data;
 		});
 	}
+
+	getQueryResults(query) {
+		const requestUrl = `${this.baseUrl}/query`;
+		return axios.post(requestUrl, query).then(data => {
+			return data.data;
+		});
+	}
 }
 
 export default GenomeAPI;


### PR DESCRIPTION
GenomeAPI.getQueryResults() function will simply return the data for a query as raw documents.