### PR TITLE
add webpack config for minification and obfuscation

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -135,7 +135,7 @@ export default (env = defaultEnv) => ({
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".json", ".jsx"]
   },
-  optimization: {
+  optimization: env.dev ? {} : {
     minimize: true,
     minimizer: [new UglifyJsPlugin({
       include: /\.(j|t)sx?$/,


### PR DESCRIPTION
This PR addresses one task in #116 
The `uglifyjs-webpack-plugin` seems to be built-in with webpack 4.0, so I didn't add that to the `package.json`.