### PR TITLE
Refactor navigation controller to directly handle adding views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ export class App extends React.Component<Props, State> {
 	protected appModel: AppModel;
 	protected viewModel: ViewModel;
 	protected appCanvas: AppCanvas;
+	protected navigationController: NavigationController;
 
 	constructor(props: Props) {
 		super(props);
@@ -204,7 +205,11 @@ export class App extends React.Component<Props, State> {
 				{errorList}
 			</Dialog>);
 		}
+
+		const navController = (<NavigationController ref={(v) => this.navigationController = v} appModel={this.appModel} viewModel={this.viewModel} views={this.state.views} />);
 		
+		if (this.navigationController) this.state.trackViewer.setNavigationController(this.navigationController);
+
 		return (
 			<MuiThemeProvider muiTheme={BasicTheme}>
 				<div>
@@ -216,7 +221,7 @@ export class App extends React.Component<Props, State> {
 						content={this.state.trackViewer}
 						pixelRatio={App.canvasPixelRatio}
 					/>
-					<NavigationController viewModel={this.viewModel} views={this.state.views} />
+					{navController}
 					{errorButton}
 					{errorDialog}
 				</div>

--- a/src/ui/TrackViewer.tsx
+++ b/src/ui/TrackViewer.tsx
@@ -9,6 +9,9 @@ import ReactObject from "./core/ReactObject";
 import Rect from "./core/Rect";
 import Panel from "./Panel";
 import TrackRow from "./TrackRow";
+import NavigationController from "../ui/components/NavigationController/NavigationController";
+import DatasetSelector from "../ui/components/DatasetSelector/DatasetSelector";
+
 import { DEFAULT_SPRING } from "./UIConstants";
 
 class TrackViewer extends Object2D {
@@ -37,6 +40,9 @@ class TrackViewer extends Object2D {
     protected grid: Object2D;
     protected addPanelButton: ReactObject;
     protected addDataTrackButton: ReactObject;
+
+    /** used to interact with the app ui */
+    protected navigationController: NavigationController;
 
     constructor() {
         super();
@@ -111,8 +117,13 @@ class TrackViewer extends Object2D {
         this.positionTrack(trackRow, false);
     }
 
+    setNavigationController = (navigationController: NavigationController) => {
+        this.navigationController = navigationController;
+    }
+
     addDatasetBrowser = () => {
-        // TODO
+        const nav = this.navigationController;
+        nav.pushView((<DatasetSelector ref={nav.bind} />));
     }
 
     addPanel(model: PanelModel, animate: boolean) {

--- a/src/ui/components/DatasetSelector/DatasetSelector.jsx
+++ b/src/ui/components/DatasetSelector/DatasetSelector.jsx
@@ -1,6 +1,5 @@
 // Dependencies
 import * as React from "react";
-import * as PropTypes from "prop-types";
 import GWASSelector from "../GWASSelector/GWASSelector.jsx";
 import GenomeSelector from "../GenomeSelector/GenomeSelector.jsx";
 import TrackSelector from "../TrackSelector/TrackSelector.jsx";
@@ -9,40 +8,36 @@ import ENCODESelector from "../ENCODESelector/ENCODESelector.jsx";
 import BooleanTrackSelector from "../BooleanTrackSelector/BooleanTrackSelector.jsx";
 import DataListItem from "../DataListItem/DataListItem.jsx";
 import ErrorDetails from "../Shared/ErrorDetails/ErrorDetails.jsx";
+import { NavigationView } from "../NavigationController/NavigationController";
+// Styles
+import "./DatasetSelector.scss";
+
 import {
   TRACK_TYPE_SEQUENCE,
   TRACK_TYPE_FUNCTIONAL,
   TRACK_TYPE_GENOME,
   TRACK_TYPE_GWAS,
-  TRACK_TYPE_EQTL,
   TRACK_TYPE_ENCODE,
-  TRACK_TYPE_3D,
   TRACK_TYPE_NETWORK,
   TRACK_TYPE_BOOLEAN
 } from "../../helpers/constants";
 
-// Styles
-import "./DatasetSelector.scss";
-
-class DatasetSelector extends React.Component {
+class DatasetSelector extends NavigationView {
   constructor(props) {
     super(props);
-    this.viewModel = props.viewModel;
-    this.appModel = props.appModel;
-    this.api = this.appModel.api;
 
     this.state = {
       dataInfo: []
     };
   }
 
-  componentDidMount() {
-    this.api.getTrackInfo().then(dataInfo => {
+  componentMountedInNavController(nav) {
+    nav.api().getTrackInfo().then(dataInfo => {
       this.setState({
         dataInfo: dataInfo,
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
       this.setState({
         error: err,
       });
@@ -51,55 +46,19 @@ class DatasetSelector extends React.Component {
 
   dataSetSelected = (trackType) => {
     if (trackType === TRACK_TYPE_GENOME) {
-      this.viewModel.pushView(
-        "Genomic Elements",
-        null,
-        <GenomeSelector appModel={this.appModel} viewModel={this.viewModel} />
-      );
+      this.controller().pushView(<GenomeSelector ref={this.controller().bind} />);
     } else if (trackType === TRACK_TYPE_GWAS) {
-      this.viewModel.pushView(
-        "GWAS Track",
-        null,
-        <GWASSelector appModel={this.appModel} viewModel={this.viewModel} />
-      );
+      this.controller().pushView(<GWASSelector ref={this.controller().bind} />);
     } else if (trackType === TRACK_TYPE_ENCODE) {
-      this.viewModel.pushView(
-        "ENCODE Track",
-        null,
-        <ENCODESelector appModel={this.appModel} viewModel={this.viewModel} />
-      );
+      this.controller().pushView(<ENCODESelector ref={this.controller().bind} />);
     } else if (trackType === TRACK_TYPE_FUNCTIONAL) {
-      this.viewModel.pushView(
-        "Functional Tracks",
-        null,
-        <FunctionalTrackSelector appModel={this.appModel} />
-      );
+      this.controller().pushView(<FunctionalTrackSelector ref={this.controller().bind} />);
     } else if (trackType === TRACK_TYPE_SEQUENCE) {
-      this.viewModel.pushView(
-        "Sequence Tracks",
-        null,
-        <TrackSelector
-          trackType={trackType}
-          appModel={this.appModel}
-          viewModel={this.viewModel}
-        />
-      );
+      this.controller().pushView(<TrackSelector trackType={trackType} ref={this.controller().bind} />);
     } else if (trackType === TRACK_TYPE_NETWORK) {
-      this.viewModel.pushView(
-        "Network Tracks",
-        null,
-        <TrackSelector
-          trackType={trackType}
-          appModel={this.appModel}
-          viewModel={this.viewModel}
-        />
-      );
+      this.controller().pushView(<TrackSelector trackType={trackType} ref={this.controller().bind} />);
     } else if (trackType === TRACK_TYPE_BOOLEAN) {
-      this.viewModel.pushView(
-        "Boolean Tracks",
-        null,
-        <BooleanTrackSelector appModel={this.appModel} />
-      );
+      this.controller().pushView(<BooleanTrackSelector ref={this.controller().bind} />);
     }
   }
 
@@ -126,10 +85,5 @@ class DatasetSelector extends React.Component {
     return <div className="dataset-selector">{dataInfoBlocks}</div>;
   }
 }
-
-DatasetSelector.propTypes = {
-  appModel: PropTypes.object,
-  viewModel: PropTypes.object
-};
 
 export default DatasetSelector;

--- a/src/ui/components/ENCODESelector/ENCODESelector.jsx
+++ b/src/ui/components/ENCODESelector/ENCODESelector.jsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import * as PropTypes from "prop-types";
 import TextField from "material-ui/TextField";
-import AutoComplete from "material-ui/AutoComplete";
+import { NavigationView } from "../NavigationController/NavigationController";
 import Slider from "material-ui/Slider";
 import RaisedButton from "material-ui/RaisedButton/RaisedButton";
 import SelectField from "material-ui/SelectField";
@@ -36,13 +36,9 @@ function reverse(value) {
   );
 }
 
-class ENCODESelector extends React.Component {
+class ENCODESelector extends NavigationView {
   constructor(props) {
     super(props);
-    if (props.appModel) {
-      this.appModel = props.appModel;
-      this.api = this.appModel.api;
-    }
     this.state = {
       title: "",
       biosampleValue: null,
@@ -85,7 +81,7 @@ class ENCODESelector extends React.Component {
         biosampleValue: newBiosampleValue,
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
       this.setState({
         error: err,
       });
@@ -120,7 +116,7 @@ class ENCODESelector extends React.Component {
         genomeTypeValue: newTypeValue
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
     });
   }
 
@@ -154,7 +150,7 @@ class ENCODESelector extends React.Component {
         checked: newChecked
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
     });
   }
 
@@ -257,11 +253,11 @@ class ENCODESelector extends React.Component {
 
   addQueryTrack = () => {
     const query = this.buildQuery();
-    this.appModel.trackMixPanel("Add ENCODE Track", { "query": query });
-    this.appModel.addAnnotationTrack(this.state.title, query);
+    this.app().trackMixPanel("Add ENCODE Track", { "query": query });
+    this.app().addAnnotationTrack(this.state.title, query);
   }
 
-  componentDidMount() {
+  componentMountedInNavController(nav) {
     this.availableChromoNames = ['Any'].concat(CHROMOSOME_NAMES);
     this.chromoNameItems = [];
     for (let i = 0; i < this.availableChromoNames.length; i++) {
@@ -384,9 +380,5 @@ class ENCODESelector extends React.Component {
     );
   }
 }
-
-ENCODESelector.propTypes = {
-  appModel: PropTypes.object
-};
 
 export default ENCODESelector;

--- a/src/ui/components/FunctionalTrackSelector/FunctionalTrackSelector.jsx
+++ b/src/ui/components/FunctionalTrackSelector/FunctionalTrackSelector.jsx
@@ -1,8 +1,7 @@
 // Dependencies
 import * as React from "react";
-import * as PropTypes from "prop-types";
 import TextField from "material-ui/TextField";
-import AutoComplete from "material-ui/AutoComplete";
+import { NavigationView } from "../NavigationController/NavigationController";
 import RaisedButton from "material-ui/RaisedButton/RaisedButton";
 import SelectField from "material-ui/SelectField";
 import MenuItem from "material-ui/MenuItem";
@@ -14,13 +13,9 @@ import ErrorDetails from "../Shared/ErrorDetails/ErrorDetails.jsx";
 // Styles
 import "./FunctionalTrackSelector.scss";
 
-class FunctionalTrackSelector extends React.Component {
+class FunctionalTrackSelector extends NavigationView {
   constructor(props) {
     super(props);
-    if (props.appModel) {
-      this.appModel = props.appModel;
-      this.api = this.appModel.api;
-    }
     this.state = {
       title: "",
       outTypeValue: null,
@@ -46,7 +41,7 @@ class FunctionalTrackSelector extends React.Component {
       builder.filterAssay(this.selectedAssay);
     }
     const infoQuery = builder.build();
-    this.api.getDistinctValues("info.outtype", infoQuery).then(data => {
+    this.api().getDistinctValues("info.outtype", infoQuery).then(data => {
       // Keep the current selection of type
       let newTypeValue = null;
       if (this.state.outTypeValue !== null) {
@@ -61,7 +56,7 @@ class FunctionalTrackSelector extends React.Component {
         outTypeValue: newTypeValue
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
     });
   }
 
@@ -77,7 +72,7 @@ class FunctionalTrackSelector extends React.Component {
       builder.filterAssay(this.selectedAssay);
     }
     const infoQuery = builder.build();
-    this.api.getDistinctValues('info.biosample', infoQuery).then(data => {
+    this.api().getDistinctValues('info.biosample', infoQuery).then(data => {
       // Keep the current selection of biosample
       let newBiosampleValue = null;
       if (this.state.biosampleValue !== null) {
@@ -92,7 +87,7 @@ class FunctionalTrackSelector extends React.Component {
         biosampleValue: newBiosampleValue,
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
       this.setState({
         error: err,
       });
@@ -111,7 +106,7 @@ class FunctionalTrackSelector extends React.Component {
       builder.filterOutType(this.selectedType);
     }
     const infoQuery = builder.build();
-    this.api.getDistinctValues("info.assay", infoQuery).then(data => {
+    this.api().getDistinctValues("info.assay", infoQuery).then(data => {
       // Keep the current selection of assay
       let newAssayValue = null;
       if (this.state.assayValue !== null) {
@@ -126,7 +121,7 @@ class FunctionalTrackSelector extends React.Component {
         assayValue: newAssayValue
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
     });
   }
 
@@ -140,7 +135,7 @@ class FunctionalTrackSelector extends React.Component {
     builder.filterAssay(this.selectedAssay);
     builder.setLimit(10);
     const infoQuery = builder.build();
-    this.api.getQueryResults(infoQuery).then(results => {
+    this.api().getQueryResults(infoQuery).then(results => {
       // Keep the current selection of assay
       const availableAccessions = [];
       for (const d of results.data) {
@@ -158,7 +153,7 @@ class FunctionalTrackSelector extends React.Component {
         accessionValue: 0
       });
     }, err => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
     });
   }
 
@@ -224,11 +219,11 @@ class FunctionalTrackSelector extends React.Component {
   }
 
   addFunctionalTrack = () => {
-    this.appModel.trackMixPanel('Add FunctionalTrack', { 'accession': this.selectedAccession });
-    this.appModel.addDataTrack(this.selectedAccession);
+    this.app().trackMixPanel('Add FunctionalTrack', { 'accession': this.selectedAccession });
+    this.app().addDataTrack(this.selectedAccession);
   }
 
-  componentDidMount() {
+  componentMountedInNavController(nav) {
     // use api to pull all available biosamples
     this.updateAvailableBiosamples();
     this.updateAvailableTypes();
@@ -333,9 +328,5 @@ class FunctionalTrackSelector extends React.Component {
     );
   }
 }
-
-FunctionalTrackSelector.propTypes = {
-  appModel: PropTypes.object
-};
 
 export default FunctionalTrackSelector;

--- a/src/ui/components/GWASSelector/GWASSelector.jsx
+++ b/src/ui/components/GWASSelector/GWASSelector.jsx
@@ -1,6 +1,5 @@
 // Dependencies
 import * as React from "react";
-import * as PropTypes from "prop-types";
 import TextField from "material-ui/TextField";
 import AutoComplete from "material-ui/AutoComplete";
 import Slider from "material-ui/Slider";
@@ -8,7 +7,8 @@ import RaisedButton from "material-ui/RaisedButton/RaisedButton";
 import SelectField from "material-ui/SelectField";
 import MenuItem from "material-ui/MenuItem";
 import ErrorDetails from "../Shared/ErrorDetails/ErrorDetails.jsx";
-import QueryBuilder, { QUERY_TYPE_INFO } from "../../models/query.js";
+import QueryBuilder from "../../models/query.js";
+import { NavigationView } from "../NavigationController/NavigationController";
 import {
   DATA_SOURCE_GWAS,
   DATA_SOURCE_CLINVAR
@@ -33,13 +33,9 @@ function reverse(value) {
   );
 }
 
-class GWASSelector extends React.Component {
+class GWASSelector extends NavigationView {
   constructor(props) {
     super(props);
-    this.appModel = props.appModel;
-    this.viewModel = props.viewModel;
-    this.api = this.appModel.api;
-
     this.state = {
       title: "",
       searchTrait: "",
@@ -60,12 +56,12 @@ class GWASSelector extends React.Component {
     }
     builder.filterType("trait");
     const infoQuery = builder.build();
-    this.api.getDistinctValues("name", infoQuery).then(data => {
+    this.api().getDistinctValues("name", infoQuery).then(data => {
       this.setState({
         traits: data
       });
     }, (err) => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
       this.setState({
         error: err,
       });
@@ -143,12 +139,12 @@ class GWASSelector extends React.Component {
 
   addQueryTrack() {
     const query = this.buildGWASQuery();
-    this.appModel.trackMixPanel('Add GWAS Track', { 'query': query });
-    this.appModel.addAnnotationTrack(this.state.title, query);
+    this.app().trackMixPanel('Add GWAS Track', { 'query': query });
+    this.app().addAnnotationTrack(this.state.title, query);
   }
 
 
-  componentDidMount() {
+  componentMountedInNavController(nav) {
     this.availableSourceNames = ['Any', 'GWAS', 'ClinVar'];
     this.searchSourceItems = [];
     for (let i = 0; i < this.availableSourceNames.length; i++) {
@@ -226,10 +222,5 @@ class GWASSelector extends React.Component {
     );
   }
 }
-
-GWASSelector.propTypes = {
-  appModel: PropTypes.object,
-  viewModel: PropTypes.object
-};
 
 export default GWASSelector;

--- a/src/ui/components/GenomeSelector/GenomeSelector.jsx
+++ b/src/ui/components/GenomeSelector/GenomeSelector.jsx
@@ -1,8 +1,7 @@
 // Dependencies
 import * as React from 'react';
-import * as PropTypes from 'prop-types';
+import { NavigationView } from "../NavigationController/NavigationController";
 import TextField from 'material-ui/TextField';
-import AutoComplete from 'material-ui/AutoComplete';
 import Slider from 'material-ui/Slider';
 import RaisedButton from 'material-ui/RaisedButton/RaisedButton';
 import SelectField from 'material-ui/SelectField';
@@ -27,13 +26,10 @@ function reverse(value) {
 }
 
 
-class GenomeSelector extends React.Component {
+class GenomeSelector extends NavigationView {
   constructor(props) {
     super(props);
-    if (props.appModel) {
-      this.appModel = props.appModel;
-      this.api = this.appModel.api;
-    }
+
     this.state = {
       title: '',
       genomeTypeValue: 0,
@@ -96,10 +92,10 @@ class GenomeSelector extends React.Component {
 
   addQueryTrack() {
     const query = this.buildGenomeQuery();
-    this.appModel.addAnnotationTrack(this.state.title, query);
+    this.app().addAnnotationTrack(this.state.title, query);
   }
 
-  componentDidMount() {
+  componentMountedInNavController(nav) {
     // some pre-defined types
     this.availableTypes = ['gene', 'exon', 'mRNA', 'promoter', 'enhancer', 'SNP'];
     this.genomeTypeItems = [];
@@ -118,7 +114,7 @@ class GenomeSelector extends React.Component {
     const builder = new QueryBuilder();
     builder.newGenomeQuery();
     const genomeQuery = builder.build();
-    this.api.getDistinctValues('type', genomeQuery).then(data => {
+    this.api().getDistinctValues('type', genomeQuery).then(data => {
       this.availableTypes = data;
       this.genomeTypeItems = [];
       for (let i = 0; i < this.availableTypes.length; i++) {
@@ -128,7 +124,7 @@ class GenomeSelector extends React.Component {
         genomeTypeValue: 0,
       });
     }, (err) => {
-      this.appModel.error(this, err);
+      this.app().error(this, err);
       this.setState({
         error: err,
       });
@@ -190,9 +186,5 @@ class GenomeSelector extends React.Component {
     );
   }
 }
-
-GenomeSelector.propTypes = {
-  appModel: PropTypes.object,
-};
 
 export default GenomeSelector;

--- a/src/ui/components/NavigationController/NavigationController.tsx
+++ b/src/ui/components/NavigationController/NavigationController.tsx
@@ -9,20 +9,82 @@ import IconButton from "material-ui/IconButton";
 // Styles
 import "./NavigationController.scss";
 import ViewModel from "../../models/ViewModel";
+import AppModel from "../../models/AppModel";
+import GenomeAPI from "../../models/api";
+
 import View from "../../View";
 
 type Props = {
   viewModel: ViewModel,
+  appModel: AppModel,
   views: Array<View>
 }
 
-type State = {}
+type State = { }
 
-class NavigationController extends React.Component<Props, State> {
+class NavigationView<Props, State> extends React.Component<{}, State> {
+  
+  private parentController: NavigationController;
 
   constructor(props: Props, ctx?: any) {
     super(props, ctx);
-    this.state = {};
+    this.parentController = null;
+  }
+
+  componentMountedInNavController(nav: NavigationController) {
+  }
+
+  public setParentNavController(nav: NavigationController) {
+    this.parentController = nav;
+  }
+  public removeFromParentNavController() {
+    this.parentController = null;
+  }
+
+  protected controller() : NavigationController {
+    return this.parentController;
+  }
+
+  public api() : GenomeAPI {
+    return this.controller().api();
+  }
+
+  public app() : AppModel {
+    return this.controller().app();
+  }
+}
+
+class NavigationController extends React.Component<Props, State> {
+  
+  public bind : (ref: any) => void;
+  
+  constructor(props: Props, ctx?: any) {
+    super(props, ctx);
+    this.state = { };
+    this.bind = (ref: any) => {
+      if (ref) {
+        (ref as NavigationView<Props, State>).setParentNavController(this);
+        (ref as NavigationView<Props, State>).componentMountedInNavController(this);
+      }
+    }
+  }
+
+  public api() : GenomeAPI {
+    return this.props.appModel.api;
+  }
+
+  public app() : AppModel {
+    return this.props.appModel;
+  }
+
+  public pushView(view: React.ReactNode) {
+    // TODO: once we get rid of viewModel in props, store in navController state
+    this.props.viewModel.pushView('', '', view);
+  }
+
+  public popView() {
+    // TODO: once we get rid of viewModel in props, update navController state
+    this.props.viewModel.popView();
   }
 
   render() {
@@ -61,3 +123,4 @@ class NavigationController extends React.Component<Props, State> {
 }
 
 export default NavigationController;
+export { NavigationView }


### PR DESCRIPTION
It would be nice if the TrackViewer received a single navigationController instance that it could use directly to push and pop views. I did this refactor to see if it could be possible.

Unfortunately, I don't think this fundamentally works -- the event-based idea we had before actually makes a lot more sense to me after writing it this way.

Would be curious to get your feedback @haxiomic, my thought is we should perhaps hack on viewModel into the appModel and expose as single `pushView(view: React.ReactNode)` method within appModel. This would be the simplest fix. This is pretty ugly.