### PR TITLE
Fix #162, move bundle.js and bundle react #unreviewed

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,16 +13,7 @@
 		<div id="cds" style="color: rgba(26, 174, 222, 0.58);"></div>
 		<div id="utr" style="color: rgba(138, 136, 191, 0.38);"></div>
 
-
-		<!-- Dependencies -->
-
-		<!-- <script src="../node_modules/react/umd/react.development.js"></script> -->
-		<!-- <script src="../node_modules/react-dom/umd/react-dom.development.js"></script> -->
-
-		<script src="../node_modules/react/umd/react.production.min.js"></script>
-		<script src="../node_modules/react-dom/umd/react-dom.production.min.js"></script>
-
 		<!-- Main -->
-		<script src="./bundle.js"></script>
+		<script src="./static/bundle.js"></script>
 	</body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,7 @@
 const path = require('path');
-const DefinePlugin = require("webpack").DefinePlugin;
+const webpack = require("webpack");
 
 const outputDirectory = `${__dirname}/dist`;
-
 
 module.exports = (env) => {
 	env = env || {};
@@ -14,7 +13,7 @@ module.exports = (env) => {
 		mode: (env.production || env.deploy) ? "production" : "development",
 
 		output: {
-			filename: "bundle.js",
+			filename: "static/bundle.js",
 			path: outputDirectory
 		},
 
@@ -75,17 +74,8 @@ module.exports = (env) => {
 
 		plugins: [
 			// pass --env to javascript build via process.env
-			new DefinePlugin({ "process.env": JSON.stringify(env) })
-		],
-
-		// When importing a module whose path matches one of the following, just
-		// assume a corresponding global variable exists and use that instead.
-		// This is important because it allows us to avoid bundling all of our
-		// dependencies, which allows browsers to cache those libraries between builds.
-		externals: {
-			"react": "React",
-			"react-dom": "ReactDOM"
-		},
+			new webpack.DefinePlugin({ "process.env": JSON.stringify(env) }),
+		]
 	}
 
 	// if in deploy mode, add deployment plugins


### PR DESCRIPTION
Fixes #162 to resolve google cloud deploy: generate bundle as `static/bundle.js` and include react with bundle (rather than loading externally)