### PR TITLE
When using filters, display all variants at all scales #unreviewed

### DIFF
--- a/src/model/data-store/VariantTileStore.ts
+++ b/src/model/data-store/VariantTileStore.ts
@@ -41,8 +41,11 @@ export type TilePayload = Array<{
 
 export class VariantTileStore extends TileStore<TilePayload, void> {
 
-    constructor(protected model: TrackModel<'variant'>, protected contig: string, tileSize: number = 1 << 15, protected macro: boolean = false) {
-        super(tileSize, 1);
+    constructor(protected model: TrackModel<'variant'>, protected contig: string) {
+        super(
+            model.toEdges == null ?  1 << 15 : 1 << 26, // tile-size
+            1
+        );
     }
 
     protected mapLodLevel(l: number) {
@@ -50,11 +53,6 @@ export class VariantTileStore extends TileStore<TilePayload, void> {
     }
 
     protected getTilePayload(tile: Tile<TilePayload>): Promise<TilePayload> | TilePayload {
-
-        if (this.model.toEdges) {// @!
-            console.log('Request', tile, this.model);
-        }
-
         let startBase = tile.x + 1;
         let endBase = startBase + tile.span;
         return axios.post(
@@ -72,10 +70,6 @@ export class VariantTileStore extends TileStore<TilePayload, void> {
             }
         ).then((r) => {
             let variants: Array<VariantGenomeNode> = r.data.data;
-
-            if (this.model.toEdges != null) { // @!
-                console.log(variants.length);
-            }
 
             return variants.map((v) => { return {
                 baseIndex: v.start - 1,

--- a/src/ui/tracks/VariantTrack.ts
+++ b/src/ui/tracks/VariantTrack.ts
@@ -58,6 +58,12 @@ export class VariantTrack extends Track<'variant'> {
             let macroOpacity: number = Scalar.linstep(this.macroLodThresholdLow, this.macroLodThresholdHigh, continuousLodLevel);
             let microOpacity: number = 1.0 - macroOpacity;
 
+            // when no filter is provided, show micro-view at all scales
+            if (this.model.toEdges != null) {
+                microOpacity = 1;
+                macroOpacity = 0;
+            }
+
             // micro-scale details
             if (microOpacity > 0) {
                 this.tileStore.getTiles(x0, x1, basePairsPerDOMPixel, true, (tile) => {


### PR DESCRIPTION
Completes "Macro variants so it's easy to find data in the query tracks" #195 