### PR TITLE
fix small issue in token box #unreviewed

### DIFF
--- a/src/ui/components/Shared/TokenBox/TokenBox.jsx
+++ b/src/ui/components/Shared/TokenBox/TokenBox.jsx
@@ -153,7 +153,7 @@ class TokenBox extends React.Component {
           query: testParse.query
         })
         // choose to display single result details or display search results
-        this.displaySearchResults(newTokens, this.state.query, true);
+        this.displaySearchResults(newTokens, testParse.query, true);
       } else {
         this.getSuggestions(newTokens, true);
       }


### PR DESCRIPTION
This fix will solve the bug when typing `variants influencing ac` and used down arrow key to select `acne`, and hit enter, the search results shows as empty.