### PR TITLE
add feature for sorting GWAS SNP search results

### DIFF
--- a/lib/sirius/QueryBuilder.ts
+++ b/lib/sirius/QueryBuilder.ts
@@ -173,6 +173,21 @@ export class QueryBuilder {
     this.query.arithmetics.push(ar);
   }
 
+  setSpecialGWASQuery() {
+    if (this.query.type !== QueryType.GENOME) {
+      throw new Error('setSpecialGWASQuery should be applied to a Genome Query.');
+    }
+    if (!this.query.toEdges || this.query.toEdges < 1) {
+      throw new Error('GWAS query should have at least 1 edge.');
+    }
+    for (const edge of this.query.toEdges) {
+      if (!edge.toNode || edge.toNode.type !== QueryType.INFO) {
+        throw new Error('The edge of GWAS query should connect to InfoNode.');
+      }
+    }
+    this.query.specialGWASQuery = true;
+  }
+
   build() {
     return JSON.parse(JSON.stringify(this.query));
   }

--- a/lib/sirius/SiriusApi.ts
+++ b/lib/sirius/SiriusApi.ts
@@ -231,6 +231,9 @@ export class SiriusApi {
         if (full) {
             requestUrl = `${this.apiUrl}/query/full`;
         }
+        if (query.specialGWASQuery) {
+            requestUrl = `${this.apiUrl}/query/gwas`;
+        }
         const options = [];
         if (startIdx !== null) {
             options.push(`result_start=${startIdx}`);

--- a/lib/sirius/queryparser.ts
+++ b/lib/sirius/queryparser.ts
@@ -84,10 +84,10 @@ function buildVariantQuery(parsePath: ParsedToken[]): any {
         const traitQuery = builder.build();
         builder.newEdgeQuery();
         builder.setToNode(traitQuery);
-        builder.filterMaxPValue(0.05);
         const edgeQuery = builder.build();
         builder.newGenomeQuery();
         builder.addToEdge(edgeQuery);
+        builder.setSpecialGWASQuery();
         return builder.build();
     }
 }

--- a/src/ui/components/SearchResultsView/SearchResultsView.jsx
+++ b/src/ui/components/SearchResultsView/SearchResultsView.jsx
@@ -140,9 +140,10 @@ class SearchResultsView extends React.Component {
 
     const location = result.contig ? (<GenomicLocation interactive={true} contig={result.contig} start={result.start} end={result.end} />) : (<div/>);
 
-    const mutation = null;
+    let mutation = null;
     let typeStyle = { backgroundColor: 'grey'}
     let typeName = result.type;
+    let pValue = null;
     if (result.type === EntityType.SNP) {
       const isInsertion = alt.split(",").filter(d => d.length > ref.length).length > 0;
       if(isInsertion) {
@@ -155,11 +156,18 @@ class SearchResultsView extends React.Component {
         typeName = 'SNP';
         mutation = (<span>{alt} <span className="allele-arrow">⟶</span> {ref}</span>);
       }
+      if('p-value' in result.info) {
+        pValue = (<div>
+          <Pills items={['p-value']} style={typeStyle} />
+          <span> {result.info['p-value'].toExponential()} </span>
+          </div>
+        );
+      }
     } else {
       typeStyle.float = 'right';
     }
     const genomicType = (<Pills items={[typeName]} style={typeStyle} />);
-    return (<span className="right-info"><div>{location}</div><div>{genomicType} {mutation} </div></span>);
+    return (<span className="right-info"><div>{location}</div><div>{genomicType} {mutation}{pValue}</div></span>);
   }
 
   rowRenderer = ({ index, key, parent, style }) => {

--- a/src/ui/components/TraitDetails/TraitDetails.jsx
+++ b/src/ui/components/TraitDetails/TraitDetails.jsx
@@ -53,6 +53,7 @@ class TraitDetails extends React.Component {
     const edgeQuery = builder.build();
     builder.newGenomeQuery();
     builder.addToEdge(edgeQuery);
+    builder.setSpecialGWASQuery();
     return builder.build();
   }
 


### PR DESCRIPTION
This PR addresses #257 

Under one of the following two circumstances, the search results will be sorted by `p-value`, which is displayed in the SearchResultsView.
1. Search for `variants influencing [trait]` in the tokenbox
2. Click "Associated Variants" button in the TraitDetailsView.

Screenshot:
![image](https://user-images.githubusercontent.com/6952367/43555061-0824647e-95c6-11e8-9842-b3a15aaffae7.png)
