### PR TITLE
skip mixpanel track for dev accounts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -303,9 +303,13 @@ export class App extends React.Component<Props, State> {
 
 	protected trackMixPanel = (event: any) => {
 		if (event.data !== null) {
-			const msg: string = event.data.msg;
-			const details: any = event.data.details;
-			mixpanel.track(msg, details);
+			// skip tracking for dev account
+			const uProf = this.state.userProfile;
+			if (uProf && uProf.user_id) {
+				const msg: string = event.data.msg;
+				const details: any = event.data.details;
+				mixpanel.track(msg, details);
+			}
 		}
 	}
 


### PR DESCRIPTION
Based on suggestions from @saliksyed, we will skip the tracking for dev accounts to make the mixpanel records cleaner.