### PR TITLE
#unreviewed Support recent changes to genome-browser

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,12 +30,13 @@ import { VariantTrackOverride } from "./track/variant/VariantTrackOverride";
 import { SiriusDataSource } from "./data-sources/SiriusDataSource";
 import { VariantTileLoaderOverride } from "./track/variant/VariantTileLoaderOverride";
 import { IntervalTileLoaderOverride } from "./track/interval/IntervalTileLoaderOverride";
+import { IntervalTrackOverride } from "./track/interval/IntervalTrackOverride";
 const deepEqual = require('fast-deep-equal');
 
 // register custom / override tracks
 GenomeBrowser.registerTrackType('annotation', AnnotationTileLoader, AnnotationTrackOverride);
 GenomeBrowser.registerTrackType('variant', VariantTileLoaderOverride, VariantTrackOverride);
-GenomeBrowser.registerTrackType('interval', IntervalTileLoaderOverride, IntervalTrack);
+GenomeBrowser.registerTrackType('interval', IntervalTileLoaderOverride, IntervalTrackOverride);
 
 // telemetry
 // add mixpanel to the global context, this is a bit of a hack but it's the usual mixpanel pattern
@@ -637,7 +638,6 @@ export class App extends React.Component<Props, State> implements Persistable<Pe
 		this.addTrack({
 			name: title,
 			type: 'interval',
-			tileStoreType: 'interval',
 			query: query,
 			blendEnabled: blendEnabled
 		});

--- a/src/track/interval/IntervalTileLoaderOverride.ts
+++ b/src/track/interval/IntervalTileLoaderOverride.ts
@@ -1,7 +1,20 @@
-import { IntervalTileLoader, Tile } from "genome-browser";
+import { IntervalTileLoader, Tile, IDataSource } from "genome-browser";
 import { SiriusApi } from "valis";
+import { IntervalTrackModelOverride } from "./IntervalTrackModelOverride";
 
 export class IntervalTileLoaderOverride extends IntervalTileLoader {
+
+    static cacheKey(model: IntervalTrackModelOverride): string {
+        return JSON.stringify(model.query);
+    }
+
+    constructor(
+        protected readonly dataSource: IDataSource,
+        protected readonly model: IntervalTrackModelOverride,
+        protected readonly contig: string,
+    ) {
+        super(dataSource, model, contig);
+    }
 
     protected getTilePayload(tile: Tile<Float32Array>): Promise<Float32Array> | Float32Array {
         // @! quality improvement; reduce perception of shivering when zooming in

--- a/src/track/interval/IntervalTrackModelOverride.ts
+++ b/src/track/interval/IntervalTrackModelOverride.ts
@@ -1,0 +1,6 @@
+import { IntervalTrackModel } from "genome-browser";
+
+export type IntervalTrackModelOverride = IntervalTrackModel & {
+    readonly query: any,
+    readonly blendEnabled: boolean,
+}

--- a/src/track/interval/IntervalTrackOverride.ts
+++ b/src/track/interval/IntervalTrackOverride.ts
@@ -1,0 +1,24 @@
+import { IntervalTrack, BlendMode, Tile } from "genome-browser";
+import { IntervalTrackModelOverride } from "./IntervalTrackModelOverride";
+
+/**
+ * Override interval track to add a 'blendEnabled' flag
+ */
+export class IntervalTrackOverride extends IntervalTrack {
+
+    constructor(model: IntervalTrackModelOverride) {
+        super(model);
+    }
+
+    protected displayTileNode(tile: Tile<any>, z: number, x0: number, span: number, continuousLodLevel: number) {
+        let node = super.displayTileNode(tile, z, x0, span, continuousLodLevel);
+
+        if (this.model.blendEnabled === false) {
+            node.opacity = 1;
+            node.blendMode = BlendMode.NONE;
+        }
+
+        return node;
+    }
+
+}

--- a/src/track/variant/VariantTileLoaderOverride.ts
+++ b/src/track/variant/VariantTileLoaderOverride.ts
@@ -34,6 +34,8 @@ type VariantInfo = {
 
 export class VariantTileLoaderOverride extends VariantTileLoader {
 
+    static cacheKey = VariantTileLoader.cacheKey;
+
     protected getTilePayload(tile: Tile<VariantTilePayload>): Promise<VariantTilePayload> | VariantTilePayload {
         const startBase = tile.x + 1;
         const endBase = startBase + tile.span;


### PR DESCRIPTION
Move custom sirius interval `query` and `blendEnabled` fields out of the core browser and into override types