### PR TITLE
improve encode search box with promoter/enhancer specific cell types

### DIFF
--- a/src/ui/components/Shared/TokenBox/TokenBox.jsx
+++ b/src/ui/components/Shared/TokenBox/TokenBox.jsx
@@ -176,7 +176,7 @@ class TokenBox extends React.Component {
 
   getSuggestionHandlers() {
     const suggestionMap = new Map();
-    ['TRAIT', 'GENE', 'CELL_TYPE', 'TUMOR_SITE', 'TARGET', 'PATHWAY'].forEach(rule => {
+    ['TRAIT', 'GENE', 'CELL_TYPE_PROMOTER', 'CELL_TYPE_ENHANCER', 'TUMOR_SITE', 'TARGET', 'PATHWAY'].forEach(rule => {
       suggestionMap.set(rule, (searchText, maxResults) => {
         return this.getThrottledResultPromise(rule, searchText, maxResults).then(d=> {
           return d;


### PR DESCRIPTION
This PR works with typescript-client PR https://github.com/VALIS-software/valis-typescript-client/pull/4 and backend PR https://github.com/VALIS-software/SIRIUS-backend/pull/102

The goal is to make the tokenbox rules of `promoters` and `enhancers` from ENCODE data easier to use.

Previously the combination of `type`, `target` and `cell-type` often results in no encode data available. 

After a short discussion with Salik, we decided to remove the `target` filter, and provide suggestions for `CELL_TYPE_PROMOTER` and `CELL_TYPE_ENHANCER` separately.

