### PR TITLE
remove pValue filter in associated Variants button in traitDetails page #unreviewed

### DIFF
--- a/src/ui/components/TraitDetails/TraitDetails.jsx
+++ b/src/ui/components/TraitDetails/TraitDetails.jsx
@@ -67,7 +67,7 @@ class TraitDetails extends React.Component {
     const traitQuery = builder.build();
     builder.newEdgeQuery();
     builder.setToNode(traitQuery);
-    builder.filterMaxPValue(0.05);
+    // builder.filterMaxPValue(0.05);
     const edgeQuery = builder.build();
     builder.newGenomeQuery();
     builder.addToEdge(edgeQuery);


### PR DESCRIPTION
Since the ClinVar traits do not have p-value for association to variants, it causes many associated variants search to show empty result, which might be confusing since the p-value filter is not shown on the web page.